### PR TITLE
Fix build warnings on macOS

### DIFF
--- a/compats.c
+++ b/compats.c
@@ -106,6 +106,9 @@ warnx(const char *fmt, ...)
  * Written by Ted Unangst
  */
 
+#if HAVE_MEMSET_S
+#define __STDC_WANT_LIB_EXT1__ 1
+#endif
 #include <string.h>
 
 /*


### PR DESCRIPTION
compats.c:122:8: warning: implicit declaration of function 'memset_s' is invalid in C99 [-Wimplicit-function-declaration]
(void)memset_s(p, n, 0, n);

compats.c:122:8: warning: this function declaration is not a prototype [-Wstrict-prototypes]

Should fix #4.

Signed-off-by: Tobias Kortkamp <tobik@FreeBSD.org>