### PR TITLE
Fix Emacs integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Add this to `~/.emacs.d/init.el` to format the current region with
   (interactive "r")
   (shell-command-on-region b e "portfmt " (current-buffer) t
                            "*portfmt errors*" t))
-(define-key makefile-bsdmake-mode-map (kbd "C-c p") 'portfmt)
+
+(with-eval-after-load 'make-mode
+  (define-key makefile-bsdmake-mode-map (kbd "C-c p") 'portfmt))
 ```
 
 ### Kakoune

--- a/portfmt.1
+++ b/portfmt.1
@@ -25,7 +25,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd November 9, 2019
+.Dd November 12, 2019
 .Dt PORTFMT 1
 .Os
 .Sh NAME
@@ -93,7 +93,8 @@ to format the current region with
                            "*portfmt errors*" t))
 .Ed
 .Bd -literal -offset indent
-(define-key makefile-bsdmake-mode-map (kbd "C-c p") 'portfmt)
+(with-eval-after-load 'make-mode
+  (define-key makefile-bsdmake-mode-map (kbd "C-c p") 'portfmt))
 .Ed
 .Ss Kakoune
 Add this to


### PR DESCRIPTION
Wrap the key definition in `with-eval-after`, because
`makefile-bsdmake-mode-map` may not yet be defined.
